### PR TITLE
Parse gst

### DIFF
--- a/examples/async.rs
+++ b/examples/async.rs
@@ -37,6 +37,7 @@ fn main() {
                                 UnifiedResponse::Tpv(t) => debug!("Tpv {:?}", t),
                                 UnifiedResponse::Sky(s) => debug!("Sky {:?}", s),
                                 UnifiedResponse::Pps(p) => debug!("PPS {:?}", p),
+                                UnifiedResponse::Gst(g) => debug!("GST {:?}", g),
                             },
                             Err(e) => {
                                 error!("Error decoding: {}", e);

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -58,6 +58,15 @@ where
                     p.device, p.real_sec, p.real_nsec, p.clock_sec, p.clock_nsec, p.precision,
                 );
             }
+            ResponseData::Gst(g) => {
+                println!(
+                    "GST {} time: {} rms: {} major: {} m minor: {} m orient: {}° lat: {} m lon: {} m alt: {} m",
+                    g.device.unwrap_or("".to_string()), g.time.unwrap_or("".to_string()),
+                    g.rms.unwrap_or(0.), g.major.unwrap_or(0.),
+                    g.minor.unwrap_or(0.), g.orient.unwrap_or(0.),
+                    g.lat.unwrap_or(0.), g.lon.unwrap_or(0.), g.alt.unwrap_or(0.),
+                );
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,20 +418,20 @@ pub struct Gst {
     pub time: Option<String>,
     /// Value of the standard deviation of the range inputs to the navigation
     /// process (range inputs include pseudoranges and DGPS corrections).
-    pub rms: Option<f64>,
+    pub rms: Option<f32>,
     /// Standard deviation of semi-major axis of error ellipse, in meters.
-    pub major: Option<f64>,
+    pub major: Option<f32>,
     /// Standard deviation of semi-minor axis of error ellipse, in meters.
-    pub minor: Option<f64>,
+    pub minor: Option<f32>,
     /// Orientation of semi-major axis of error ellipse, in degrees from true
     /// north.
-    pub orient: Option<f64>,
+    pub orient: Option<f32>,
     /// Standard deviation of latitude error, in meters.
-    pub lat: Option<f64>,
+    pub lat: Option<f32>,
     /// Standard deviation of longitude error, in meters.
-    pub lon: Option<f64>,
+    pub lon: Option<f32>,
     /// Standard deviation of altitude error, in meters.
-    pub alt: Option<f64>,
+    pub alt: Option<f32>,
 }
 
 /// Responses from `gpsd` after handshake (i.e. the payload)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,6 +407,33 @@ pub struct Pps {
     pub precision: f32,
 }
 
+/// Pseudorange noise report.
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+pub struct Gst {
+    /// Name of originating device.
+    pub device: Option<String>,
+    /// Time/date stamp in ISO8601 format, UTC. May have a fractional part of up
+    /// to .001 sec precision.
+    pub time: Option<String>,
+    /// Value of the standard deviation of the range inputs to the navigation
+    /// process (range inputs include pseudoranges and DGPS corrections).
+    pub rms: Option<f64>,
+    /// Standard deviation of semi-major axis of error ellipse, in meters.
+    pub major: Option<f64>,
+    /// Standard deviation of semi-minor axis of error ellipse, in meters.
+    pub minor: Option<f64>,
+    /// Orientation of semi-major axis of error ellipse, in degrees from true
+    /// north.
+    pub orient: Option<f64>,
+    /// Standard deviation of latitude error, in meters.
+    pub lat: Option<f64>,
+    /// Standard deviation of longitude error, in meters.
+    pub lon: Option<f64>,
+    /// Standard deviation of altitude error, in meters.
+    pub alt: Option<f64>,
+}
+
 /// Responses from `gpsd` after handshake (i.e. the payload)
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
@@ -417,6 +444,7 @@ pub enum ResponseData {
     Tpv(Tpv),
     Sky(Sky),
     Pps(Pps),
+    Gst(Gst),
 }
 
 /// All known `gpsd` responses (handshake + normal operation).
@@ -432,6 +460,7 @@ pub enum UnifiedResponse {
     Tpv(Tpv),
     Sky(Sky),
     Pps(Pps),
+    Gst(Gst),
 }
 
 /// Errors during handshake or data acquisition.


### PR DESCRIPTION
This parses an additional JSON object emitted by gpsd: `GST`, or the pseudorange noise report.

I copied the values from here:

https://gpsd.gitlab.io/gpsd/gpsd_json.html

This addresses #3. I tested it on my hardware and it parses as expected now.