### PR TITLE
Add status field to TPV

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,6 +235,8 @@ where
 pub struct Tpv {
     /// Name of the originating device.
     pub device: Option<String>,
+    /// GPS fix status.
+    pub status: Option<i32>,
     /// NMEA mode, see `Mode` enum.
     #[serde(deserialize_with = "mode_from_str")]
     pub mode: Mode,


### PR DESCRIPTION
I noticed that the `TPV` JSON object has an optional `status` field. It is [mentioned here](https://gpsd.gitlab.io/gpsd/gpsd_json.html). The documentation (currently) says that if this field is present, its only value is 2, indicating a DGPS fix.

So since it is only `None` or `Some(2)`, at first I thought this could just be represented as a `bool` or as a single-value `enum`. However, with gpsd version 3.19, this has been expanded to include [additional values](https://gitlab.com/gpsd/gpsd/blob/release-3.19/gps.h#L2161). Additionally, if the underlying value is a 0 (no fix) or 1 (GPS fix without DGPS) it [isn't emitted in the JSON output](https://gitlab.com/gpsd/gpsd/blob/release-3.19/gpsd_json.c#L137).

So in the interest of simplicity, this change simply exposes the optional integer value. Perhaps it could be extended to be an `enum` covering more values, although unfortunately gpsd doesn't actually write two of the values (0 and 1) and so they're essentially both aliased to `None`.