### PR TITLE
Correct some JSON schema

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,11 +302,11 @@ pub struct Satellite {
     #[serde(rename = "PRN")]
     pub prn: i16,
     /// Elevation in degrees.
-    pub el: f32,
+    pub el: Option<f32>,
     /// Azimuth, degrees from true north.
-    pub az: f32,
+    pub az: Option<f32>,
     /// Signal strength in dB.
-    pub ss: f32,
+    pub ss: Option<f32>,
     /// Used in current solution? (SBAS/WAAS/EGNOS satellites may be
     /// flagged used if the solution has corrections from them, but
     /// not all drivers make this information available.).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ impl fmt::Display for Mode {
     }
 }
 
-fn mode_from_str<'de, D>(deserializer: D) -> Result<Mode, D::Error>
+pub fn mode_from_str<'de, D>(deserializer: D) -> Result<Mode, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,16 @@ pub struct Tpv {
     /// Estimated timestamp error (%f, seconds, 95% confidence).
     /// Present if time is present.
     pub ept: Option<f32>,
+    pub leapseconds: Option<i32>,
+    /// MSL altitude in metres
+    #[serde(rename = "altMSL")]
+    pub alt_msl: Option<f32>,
+    /// Altitude height above ellipsoid (elipsoid is unspecified, but probably WGS48)
+    #[serde(rename = "altHAE")]
+    pub alt_hae: Option<f32>,
+    /// Geoid separation between whatever geoid the device uses and WGS84, in metres
+    #[serde(rename = "geoidSep")]
+    pub geoid_sep: Option<f32>,
     /// Latitude in degrees: +/- signifies North/South. Present
     /// when mode is 2 or 3.
     pub lat: Option<f64>,
@@ -279,6 +289,8 @@ pub struct Tpv {
     pub eps: Option<f32>,
     /// Climb/sink error estimate in meters/sec, 95% confidence.
     pub epc: Option<f32>,
+    /// Horizontal 2D position error in metres
+    pub eph: Option<f32>,
 }
 
 /// Detailed satellite information.
@@ -290,15 +302,18 @@ pub struct Satellite {
     #[serde(rename = "PRN")]
     pub prn: i16,
     /// Elevation in degrees.
-    pub el: i16,
+    pub el: f32,
     /// Azimuth, degrees from true north.
-    pub az: i16,
+    pub az: f32,
     /// Signal strength in dB.
-    pub ss: i16,
+    pub ss: f32,
     /// Used in current solution? (SBAS/WAAS/EGNOS satellites may be
     /// flagged used if the solution has corrections from them, but
     /// not all drivers make this information available.).
     pub used: bool,
+    pub gnssid: Option<u8>,
+    pub svid: Option<u16>,
+    pub health: Option<u8>, 
 }
 
 /// Satellites information.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ impl fmt::Display for Mode {
     }
 }
 
-pub fn mode_from_str<'de, D>(deserializer: D) -> Result<Mode, D::Error>
+fn mode_from_str<'de, D>(deserializer: D) -> Result<Mode, D::Error>
 where
     D: Deserializer<'de>,
 {


### PR DESCRIPTION
Mainly fixes a parsing error when azimuth/elevation/signal strength were returned as floating point values. Also adds some (not all) missing fields to the `Tpv` struct, following https://gpsd.gitlab.io/gpsd/gpsd_json.html