### PR TITLE
Change Satellite's el, az, ss members to be floats

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,11 +290,11 @@ pub struct Satellite {
     #[serde(rename = "PRN")]
     pub prn: i16,
     /// Elevation in degrees.
-    pub el: f32,
+    pub el: Option<f32>,
     /// Azimuth, degrees from true north.
-    pub az: f32,
+    pub az: Option<f32>,
     /// Signal strength in dB.
-    pub ss: f32,
+    pub ss: Option<f32>,
     /// Used in current solution? (SBAS/WAAS/EGNOS satellites may be
     /// flagged used if the solution has corrections from them, but
     /// not all drivers make this information available.).
@@ -691,9 +691,9 @@ mod tests {
                 assert_eq!(sky.device.unwrap(), "adevice");
                 let actual = &sky.satellites[0];
                 assert!(actual.prn == 123);
-                assert!(actual.el == 1.0);
-                assert!(actual.az == 2.0);
-                assert!(actual.ss == 3.0);
+                assert!(actual.el == Some(1.0));
+                assert!(actual.az == Some(2.0));
+                assert!(actual.ss == Some(3.0));
                 Ok(())
             }
             _ => Err(()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -603,7 +603,7 @@ pub fn get_data(reader: &mut dyn io::BufRead) -> Result<ResponseData, GpsdError>
 
 #[cfg(test)]
 mod tests {
-    use super::{get_data, handshake, GpsdError, Mode, ResponseData, Satellite, ENABLE_WATCH_CMD};
+    use super::{get_data, handshake, GpsdError, Mode, ResponseData, ENABLE_WATCH_CMD};
     use std::io::BufWriter;
 
     #[test]
@@ -690,16 +690,11 @@ mod tests {
             ResponseData::Sky(sky) => {
                 assert_eq!(sky.device.unwrap(), "adevice");
                 let actual = &sky.satellites[0];
-                match actual {
-                    Satellite {
-                        prn: 123,
-                        el: 1,
-                        az: 2,
-                        ss: 3,
-                        used: true,
-                    } => Ok(()),
-                    _ => Err(()),
-                }
+                assert!(actual.prn == 123);
+                assert!(actual.el == 1.0);
+                assert!(actual.az == 2.0);
+                assert!(actual.ss == 3.0);
+                Ok(())
             }
             _ => Err(()),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,11 +290,11 @@ pub struct Satellite {
     #[serde(rename = "PRN")]
     pub prn: i16,
     /// Elevation in degrees.
-    pub el: i16,
+    pub el: f32,
     /// Azimuth, degrees from true north.
-    pub az: i16,
+    pub az: f32,
     /// Signal strength in dB.
-    pub ss: i16,
+    pub ss: f32,
     /// Used in current solution? (SBAS/WAAS/EGNOS satellites may be
     /// flagged used if the solution has corrections from them, but
     /// not all drivers make this information available.).


### PR DESCRIPTION
These are floats (e.g., `35.0` for `el`) in the JSON that comes from my system's `gpsd`.

This would be a breaking change in the library.

This is in response to / a fix for #8.