### PR TITLE
Update tokio and other dev dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ serde_derive = "1.0"
 serde_json = "1.0"
 
 [dev-dependencies]
-itertools = "0.7"
-env_logger = "0.6"
-futures = "0.1.27"
-tokio = "0.1"
+itertools = "0.11"
+env_logger = "0.10"
+futures = "0.3"
+tokio = { version = "1.33", features = ["rt", "macros", "net"] }
+tokio-util = { version = "0.7", features = ["codec"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Marcus Geiger"]
 description = "The gpsd_proto module contains types and functions to connect to gpsd to get GPS coordinates and satellite information."
 documentation = "https://docs.rs/gpsd_proto/"
-edition = "2018"
+edition = "2021"
 homepage = "https://github.com/bwolf/gpsd_proto.git"
 keywords = ["protocol", "gps"]
 license = "Apache-2.0"

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,53 +1,52 @@
 #[macro_use]
 extern crate log;
 
-use futures::prelude::*;
-use futures::stream::Stream;
+use futures::{future::ready, prelude::*};
 use gpsd_proto::UnifiedResponse;
+use std::error::Error;
 use std::net::SocketAddr;
-use tokio::codec::Framed;
-use tokio::codec::LinesCodec;
 use tokio::net::TcpStream;
+use tokio_util::codec::{Framed, LinesCodec};
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
     info!("Starting");
 
     let addr: SocketAddr = "127.0.0.1:2947".parse().unwrap();
 
-    let program = TcpStream::connect(&addr)
-        .and_then(|sock| {
-            let framed = Framed::new(sock, LinesCodec::new());
-            framed
-                .send(gpsd_proto::ENABLE_WATCH_CMD.to_string())
-                .and_then(|framed| {
-                    framed.for_each(|line| {
-                        trace!("Raw {}", &line);
-                        match serde_json::from_str(&line) {
-                            Ok(rd) => match rd {
-                                UnifiedResponse::Version(v) => {
-                                    if v.proto_major < gpsd_proto::PROTO_MAJOR_MIN {
-                                        panic!("Gpsd major version mismatch");
-                                    }
-                                    info!("Gpsd version {} connected", v.rev);
-                                }
-                                UnifiedResponse::Devices(_) => {}
-                                UnifiedResponse::Watch(_) => {}
-                                UnifiedResponse::Device(d) => debug!("Device {:?}", d),
-                                UnifiedResponse::Tpv(t) => debug!("Tpv {:?}", t),
-                                UnifiedResponse::Sky(s) => debug!("Sky {:?}", s),
-                                UnifiedResponse::Pps(p) => debug!("PPS {:?}", p),
-                                UnifiedResponse::Gst(g) => debug!("GST {:?}", g),
-                            },
-                            Err(e) => {
-                                error!("Error decoding: {}", e);
-                            }
-                        };
-                        Ok(())
-                    })
-                })
-        })
-        .map_err(|e| error!("Failure {:?}", e));
+    let stream = TcpStream::connect(&addr).await?;
+    let mut framed = Framed::new(stream, LinesCodec::new());
 
-    tokio::run(program);
+    framed.send(gpsd_proto::ENABLE_WATCH_CMD).await?;
+    framed
+        .try_for_each(|line| {
+            trace!("Raw {line}");
+
+            match serde_json::from_str(&line) {
+                Ok(rd) => match rd {
+                    UnifiedResponse::Version(v) => {
+                        if v.proto_major < gpsd_proto::PROTO_MAJOR_MIN {
+                            panic!("Gpsd major version mismatch");
+                        }
+                        info!("Gpsd version {} connected", v.rev);
+                    }
+                    UnifiedResponse::Devices(_) => {}
+                    UnifiedResponse::Watch(_) => {}
+                    UnifiedResponse::Device(d) => debug!("Device {d:?}"),
+                    UnifiedResponse::Tpv(t) => debug!("Tpv {t:?}"),
+                    UnifiedResponse::Sky(s) => debug!("Sky {s:?}"),
+                    UnifiedResponse::Pps(p) => debug!("PPS {p:?}"),
+                    UnifiedResponse::Gst(g) => debug!("GST {g:?}"),
+                },
+                Err(e) => {
+                    error!("Error decoding: {e}");
+                }
+            };
+
+            ready(Ok(()))
+        })
+        .await?;
+
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ pub struct Version {
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct Devices {
-    devices: Vec<DeviceInfo>,
+    pub devices: Vec<DeviceInfo>,
 }
 
 /// Single device information as reported by `gpsd`.


### PR DESCRIPTION
This brings things up-to-date:

* Newer versions of `tokio` and `futures` used for the example
* Update other dev-dependencies
* Migrate to 2021 edition (no changes are actually needed)
* Address a warning about an unused private field