### PR TITLE
Make the `satellites` field optional

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -38,12 +38,15 @@ where
                 );
             }
             ResponseData::Sky(sky) => {
-                let sats = sky
-                    .satellites
-                    .iter()
-                    .filter(|sat| sat.used)
-                    .map(|sat| sat.prn.to_string())
-                    .join(",");
+                let sats = sky.satellites.map_or_else(
+                    || "(none)".to_owned(),
+                    |sats| {
+                        sats.iter()
+                            .filter(|sat| sat.used)
+                            .map(|sat| sat.prn.to_string())
+                            .join(",")
+                    },
+                );
                 println!(
                     "Sky xdop {:4.2} ydop {:4.2} vdop {:4.2}, satellites {}",
                     sky.xdop.unwrap_or(0.0),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,7 +367,7 @@ pub struct Sky {
     /// estimate.
     pub pdop: Option<f32>,
     /// List of satellite objects in skyview.
-    pub satellites: Vec<Satellite>,
+    pub satellites: Option<Vec<Satellite>>,
 }
 
 /// This message is emitted each time the daemon sees a valid PPS (Pulse Per
@@ -704,7 +704,7 @@ mod tests {
         let test = match r {
             ResponseData::Sky(sky) => {
                 assert_eq!(sky.device.unwrap(), "aDevice");
-                let actual = &sky.satellites[0];
+                let actual = &sky.satellites.unwrap()[0];
                 assert_eq!(actual.prn, 123);
                 assert_eq!(actual.el, Some(1.));
                 assert_eq!(actual.az, Some(2.));


### PR DESCRIPTION
This matches the behavior as of gpsd 3.25, where a `SKY` JSON object may be emitted without a `satellites` key.

On my device, it looks like two `SKY` messages get emitted every second, where one has them has `satellites` and the other doesn't.