### PR TITLE
Add magnetic variation and track to Tpv

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,10 @@ pub struct Tpv {
     pub epc: Option<f32>,
     /// Horizontal 2D position error in meters.
     pub eph: Option<f32>,
+    /// Course over ground, degrees magnetic.
+    pub magtrack: Option<f32>,
+    /// Magnetic variation, degrees.
+    pub magvar: Option<f32>,
 }
 
 /// Detailed satellite information.


### PR DESCRIPTION
## Description


This pull request suggests adding the `magtrack` and `magvar` fields to the `tpv` struct in order to comply with the [ITxPT](https://itxpt.org/) recommendations. These fields are already included in the [gpsd documentation](https://gpsd.io/gpsd_json.html#_version).


## Changes Made


- Added the `magtrack` field to the `tpv` struct to represent the course over ground, degrees magnetic.

- Added the `magvar` field to the `tpv` struct to represent the magnetic variation degrees.