### PR TITLE
Avoid crashing on invalid utf-8 and avoid an extra allocation on logging

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -542,7 +542,7 @@ pub fn handshake(
     // Get VERSION
     let mut data = Vec::new();
     reader.read_until(b'\n', &mut data)?;
-    trace!("{}", String::from_utf8(data.clone()).unwrap());
+    trace!("{}", String::from_utf8_lossy(&data));
     let msg: ResponseHandshake = serde_json::from_slice(&data)?;
     match msg {
         ResponseHandshake::Version(v) => {
@@ -552,7 +552,7 @@ pub fn handshake(
         }
         _ => {
             return Err(GpsdError::UnexpectedGpsdReply(
-                String::from_utf8(data).unwrap(),
+                String::from_utf8_lossy(&data).into_owned(),
             ))
         }
     }
@@ -564,13 +564,13 @@ pub fn handshake(
     // Get DEVICES
     let mut data = Vec::new();
     reader.read_until(b'\n', &mut data)?;
-    trace!("{}", String::from_utf8(data.clone()).unwrap());
+    trace!("{}", String::from_utf8_lossy(&data));
     let msg: ResponseHandshake = serde_json::from_slice(&data)?;
     match msg {
         ResponseHandshake::Devices(_) => {}
         _ => {
             return Err(GpsdError::UnexpectedGpsdReply(
-                String::from_utf8(data).unwrap(),
+                String::from_utf8_lossy(&data).into_owned(),
             ))
         }
     }
@@ -578,7 +578,7 @@ pub fn handshake(
     // Get WATCH
     let mut data = Vec::new();
     reader.read_until(b'\n', &mut data)?;
-    trace!("{}", String::from_utf8(data.clone()).unwrap());
+    trace!("{}", String::from_utf8_lossy(&data));
     let msg: ResponseHandshake = serde_json::from_slice(&data)?;
     match msg {
         ResponseHandshake::Watch(w) => {
@@ -588,13 +588,13 @@ pub fn handshake(
                 w.nmea.unwrap_or(false),
             ) {
                 return Err(GpsdError::WatchFail(
-                    String::from_utf8(data).unwrap(),
+                    String::from_utf8_lossy(&data).into_owned(),
                 ));
             }
         }
         _ => {
             return Err(GpsdError::UnexpectedGpsdReply(
-                String::from_utf8(data).unwrap(),
+                String::from_utf8_lossy(&data).into_owned(),
             ))
         }
     }
@@ -611,7 +611,7 @@ pub fn handshake(
 pub fn get_data(reader: &mut dyn io::BufRead) -> Result<ResponseData, GpsdError> {
     let mut data = Vec::new();
     reader.read_until(b'\n', &mut data)?;
-    trace!("{}", String::from_utf8(data.clone()).unwrap());
+    trace!("{}", String::from_utf8_lossy(&data));
     let msg: ResponseData = serde_json::from_slice(&data)?;
     Ok(msg)
 }


### PR DESCRIPTION

The change achieves 2 things:

- If GPSD somehow sends invalid UTF-8, we avoid crashing and instead replace invalid UTF-8 with the replacement character, which means we continue to JSON deserialization which will fail and return an error the user can handle.
- For calls to trace! we avoid the extra allocation by not cloning the payload