### PR TITLE
fix serde, add error response

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,7 @@ pub struct Device {
 
 /// Type of GPS fix.
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
 pub enum Mode {
     /// No fix at all.
     NoFix,
@@ -477,6 +478,7 @@ pub enum UnifiedResponse {
     Sky(Sky),
     Pps(Pps),
     Gst(Gst),
+    Error(ErrorResponse),
 }
 
 /// Errors during handshake or data acquisition.
@@ -492,6 +494,13 @@ pub enum GpsdError {
     UnexpectedGpsdReply(String),
     /// Failed to enable watch.
     WatchFail(String),
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+pub struct ErrorResponse {
+    /// Error message.
+    pub message: String,
 }
 
 impl From<io::Error> for GpsdError {


### PR DESCRIPTION
hiya, playing with this and ran into a couple of issues that this PR fixes:

- resovled a compile error when `serialize` is enabled because `Mode` is missing the attribute
- adds the gpsd error type to `UnifiedResponse` 